### PR TITLE
[FIX] run with python3, avoid infinite loop

### DIFF
--- a/plugin/background_make.vim
+++ b/plugin/background_make.vim
@@ -8,6 +8,7 @@ import re
 vim.command("up")
 makeprg = vim.eval("&makeprg")
 servername = vim.eval("v:servername")
+assert servername, "Please run vim with --servername <a_name>"
 args = vim.eval("a:args")
 makeprg = vim.eval("expand(&makeprg)")
 

--- a/plugin/background_make.vim
+++ b/plugin/background_make.vim
@@ -1,5 +1,5 @@
 fun! <SID>BackgroundMake(args)
-python << endpython
+python3 << endpython
 import vim
 import os
 import tempfile


### PR DESCRIPTION
This has two fixes.
* One from https://github.com/GjjvdBurg/vim-background-make to run with python3;
* Other one is to avoid infinite loop by making sure servername is set.